### PR TITLE
Narrator-tools patch

### DIFF
--- a/tabbed-chatlog.js
+++ b/tabbed-chatlog.js
@@ -379,7 +379,7 @@ Hooks.on("closeSceneConfig", (app, html, data) => {
 });
 
 Hooks.on('ready', () => {
-  if (window.NarratorTools !== undefined) { NarratorTools._msgtype = 2; }
+  if (game.modules.get('narrator-tools')) { NarratorTools._msgtype = 2; }
 
   turndown = new TurndownService();
 });


### PR DESCRIPTION
I just noticed the old `window` version no longer works. This is the way it should've been in the first place.